### PR TITLE
add special CFN stack hook targets to hook schema

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -116,6 +116,8 @@ BASIC_TYPE_MAPPINGS = {
 
 MARKDOWN_RESERVED_CHARACTERS = frozenset({"^", "*", "+", ".", "(", "[", "{", "#"})
 
+HOOK_SPECIAL_TARGET_NAMES = frozenset(("STACK", "CHANGE_SET"))
+
 
 def escape_markdown(string):
     """Escapes the reserved Markdown characters."""
@@ -1223,6 +1225,9 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         }
 
         LOG.debug("Hook schema target names: %s", str(target_names))
+
+        if self.artifact_type == ARTIFACT_TYPE_HOOK:
+            target_names = list(filter(lambda x: x not in HOOK_SPECIAL_TARGET_NAMES, target_names))
 
         if local_only:
             targets = TypeNameResolver.resolve_type_names_locally(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2432,10 +2432,11 @@ def test__load_target_info_for_hooks(project):
     project.schema = {
         "handlers": {
             "preCreate": {
-                "targetNames": ["AWS::TestHook::Target", "AWS::TestHook::OtherTarget"]
+                "targetNames": ["AWS::TestHook::Target", "AWS::TestHook::OtherTarget", "STACK", "CHANGE_SET"]
             },
             "preUpdate": {
                 "targetNames": [
+                    "CHANGE_SET",
                     "AWS::TestHookOne::Target",
                     "AWS::TestHookTwo::Target",
                     "AWS::ArrayHook::Target",


### PR DESCRIPTION
*Issue #, if available:* https://sim.amazon.com/issues/CFN-Danforth-882

*Description of changes:*

As part of stack-level hooks, customers will be able to author hooks that target stack-level CFN events. In order for customers to specify a hook as targeting a stack or change set, they'll modify the hook schemas with new values in the `targetNames` list of each handler.

The RPDK does validation of target names, and that validation must be updated to allow new values `STACK` and `CHANGE_SET`.

## Testing

Ran `pytest`:

```
991 passed, 59 warnings in 11.82s
```

Created a hook with this schema:

```
{
    "typeName": "LaoCorp::Testing::SimpleHook2",
    "description": "Example resource SSE (Server Side Encryption) verification hook",
    "sourceUrl": "https://github.com/aws-cloudformation/example-sse-hook",
    "documentationUrl": "https://github.com/aws-cloudformation/example-sse-hook/blob/master/README.md",
    "typeConfiguration": {
        "properties": {
            "EncryptionAlgorithm": {
                "description": "Encryption algorithm for SSE",
                "type": "string"
            }
        },
        "additionalProperties": false
    },
    "required": [],
    "handlers": {
        "preCreate": {
            "targetNames": [
                "AWS::SSM::Parameter",
                "AWS::S3::Bucket",
                "STACK",
                "CHANGE_SET"
            ],
            "permissions": []
        },
        "preUpdate": {
            "targetNames": [],
            "permissions": []
        }
    },
    "additionalProperties": false
}
```

**Link to hook with the new targets: https://tiny.amazon.com/h6heeccs/IsenLink and screenshot:**

![Screenshot 2024-02-14 at 12 36 49 PM](https://github.com/brianlaoaws/cloudformation-cli/assets/104795877/ea9ffe6c-43d4-4dc8-99e3-9410eb0c1c4c)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
